### PR TITLE
Add requirements files

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,10 @@
+-i https://pypi.org/simple
+black==23.9.1
+click==8.1.7 ; python_version >= '3.7'
+colorama==0.4.6 ; platform_system == 'Windows'
+mypy==1.5.1
+mypy-extensions==1.0.0 ; python_version >= '3.5'
+packaging==23.1 ; python_version >= '3.7'
+pathspec==0.11.2 ; python_version >= '3.7'
+platformdirs==3.10.0 ; python_version >= '3.7'
+typing-extensions==4.7.1 ; python_version < '3.12'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-i https://pypi.org/simple
+typing-extensions==4.7.1 ; python_version < '3.12'


### PR DESCRIPTION
Losos uses pipenv, but keep requirements also in [dev-]requirements.txt files for compatibility with other tools.